### PR TITLE
ICU comparison routines should use case folding, not case mapping

### DIFF
--- a/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
+++ b/src/libraries/Common/src/Interop/Unix/System.Globalization.Native/Interop.Casing.cs
@@ -14,10 +14,10 @@ internal static partial class Interop
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCase")]
         internal static extern unsafe void ChangeCase(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
 
-        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseInvariant")]
-        internal static extern unsafe void ChangeCaseInvariant(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
-
         [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_ChangeCaseTurkish")]
         internal static extern unsafe void ChangeCaseTurkish(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity, bool bToUpper);
+
+        [DllImport(Libraries.GlobalizationNative, CharSet = CharSet.Unicode, EntryPoint = "GlobalizationNative_SimpleCaseFold")]
+        internal static extern unsafe void SimpleCaseFold(char* src, int srcLen, char* dstBuffer, int dstBufferCapacity);
     }
 }

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.c
@@ -13,11 +13,32 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wsign-conversion"
 
+
+// Performs simple case folding of a code point, but forbids a non-ASCII code point
+// from folding to an ASCII code point. If this occurs the API will return the original
+// code point value.
+static UChar32 CaseFoldCodePoint(UChar32 codePoint)
+{
+    UChar32 codePointFolded = u_foldCase(codePoint, U_FOLD_CASE_DEFAULT);
+
+    // Subtracting 0x80 from the code point value will cause ASCII code points to become negative
+    // and non-ASCII code points to become non-negative. Since these code paths are expected to
+    // be called when we have a mix of ASCII and non-ASCII chars, this allows the branch condition
+    // to almost always evaluate to false.
+
+    if ((codePoint - 0x80) ^ (codePointFolded - 0x80) < 0)
+    {
+        codePointFolded = codePoint;
+    }
+
+    return codePointFolded;
+}
+
 /*
 Function:
 ChangeCase
 
-Performs upper or lower casing of a string into a new buffer.
+Performs simple case mapping (upper or lower) of a string into a new buffer.
 No special casing is performed beyond that provided by ICU.
 */
 void GlobalizationNative_ChangeCase(
@@ -53,51 +74,6 @@ void GlobalizationNative_ChangeCase(
         {
             U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
             dstCodepoint = u_tolower(srcCodepoint);
-            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
-        }
-    }
-}
-
-/*
-Function:
-ChangeCaseInvariant
-
-Performs upper or lower casing of a string into a new buffer.
-Special casing is performed to ensure that invariant casing
-matches that of Windows in certain situations, e.g. Turkish i's.
-*/
-void GlobalizationNative_ChangeCaseInvariant(
-    const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength, int32_t bToUpper)
-{
-    // See algorithmic comment in ChangeCase.
-
-    UBool isError = FALSE;
-    int32_t srcIdx = 0, dstIdx = 0;
-    UChar32 srcCodepoint, dstCodepoint;
-
-    if (bToUpper)
-    {
-        while (srcIdx < cwSrcLength)
-        {
-            // On Windows with InvariantCulture, the LATIN SMALL LETTER DOTLESS I (U+0131)
-            // capitalizes to itself, whereas with ICU it capitalizes to LATIN CAPITAL LETTER I (U+0049).
-            // We special case it to match the Windows invariant behavior.
-            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-            dstCodepoint = ((srcCodepoint == (UChar32)0x0131) ? (UChar32)0x0131 : u_toupper(srcCodepoint));
-            U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
-            assert(isError == FALSE && srcIdx == dstIdx);
-        }
-    }
-    else
-    {
-        while (srcIdx < cwSrcLength)
-        {
-            // On Windows with InvariantCulture, the LATIN CAPITAL LETTER I WITH DOT ABOVE (U+0130)
-            // lower cases to itself, whereas with ICU it lower cases to LATIN SMALL LETTER I (U+0069).
-            // We special case it to match the Windows invariant behavior.
-            U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
-            dstCodepoint = ((srcCodepoint == (UChar32)0x0130) ? (UChar32)0x0130 : u_tolower(srcCodepoint));
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
             assert(isError == FALSE && srcIdx == dstIdx);
         }
@@ -143,6 +119,29 @@ void GlobalizationNative_ChangeCaseTurkish(
             U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
             assert(isError == FALSE && srcIdx == dstIdx);
         }
+    }
+}
+
+/*
+Function:
+SimpleCaseFold
+
+Performs simple case folding of a string into a new buffer.
+Non-ASCII code points are not mapped to ASCII code points.
+*/
+void GlobalizationNative_SimpleCaseFold(
+    const UChar* lpSrc, int32_t cwSrcLength, UChar* lpDst, int32_t cwDstLength)
+{
+    UBool isError = FALSE;
+    int32_t srcIdx = 0, dstIdx = 0;
+    UChar32 srcCodepoint, dstCodepoint;
+
+    while (srcIdx < cwSrcLength)
+    {
+        U16_NEXT(lpSrc, srcIdx, cwSrcLength, srcCodepoint);
+        dstCodepoint = CaseFoldCodePoint(srcCodepoint);
+        U16_APPEND(lpDst, dstIdx, cwDstLength, dstCodepoint, isError);
+        assert(isError == FALSE && srcIdx == dstIdx);
     }
 }
 

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_casing.h
@@ -5,20 +5,21 @@
 #include "pal_compiler.h"
 #include "pal_locale.h"
 
+static UChar32 CaseFoldCodePoint(UChar32 codePoint);
+
 DLLEXPORT void GlobalizationNative_ChangeCase(const UChar* lpSrc,
                                               int32_t cwSrcLength,
                                               UChar* lpDst,
                                               int32_t cwDstLength,
                                               int32_t bToUpper);
 
-DLLEXPORT void GlobalizationNative_ChangeCaseInvariant(const UChar* lpSrc,
-                                                       int32_t cwSrcLength,
-                                                       UChar* lpDst,
-                                                       int32_t cwDstLength,
-                                                       int32_t bToUpper);
-
 DLLEXPORT void GlobalizationNative_ChangeCaseTurkish(const UChar* lpSrc,
                                                      int32_t cwSrcLength,
                                                      UChar* lpDst,
                                                      int32_t cwDstLength,
                                                      int32_t bToUpper);
+
+DLLEXPORT void GlobalizationNative_SimpleCaseFold(const UChar* lpSrc,
+                                                  int32_t cwSrcLength,
+                                                  UChar* lpDst,
+                                                  int32_t cwDstLength);

--- a/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.h
+++ b/src/libraries/Native/Unix/System.Globalization.Native/pal_icushim.h
@@ -37,6 +37,7 @@
 // List of all functions from the ICU libraries that are used in the System.Globalization.Native.so
 #define FOR_ALL_UNCONDITIONAL_ICU_FUNCTIONS \
     PER_FUNCTION_BLOCK(u_charsToUChars, libicuuc) \
+    PER_FUNCTION_BLOCK(u_foldCase, libicuuc) \
     PER_FUNCTION_BLOCK(u_getVersion, libicuuc) \
     PER_FUNCTION_BLOCK(u_strlen, libicuuc) \
     PER_FUNCTION_BLOCK(u_strncpy, libicuuc) \
@@ -145,6 +146,7 @@ FOR_ALL_ICU_FUNCTIONS
 // Redefine all calls to ICU functions as calls through pointers that are set
 // to the functions of the selected version of ICU in the initialization.
 #define u_charsToUChars(...) u_charsToUChars_ptr(__VA_ARGS__)
+#define u_foldcase(...) u_foldCase_ptr(__VA_ARGS__)
 #define u_getVersion(...) u_getVersion_ptr(__VA_ARGS__)
 #define u_strlen(...) u_strlen_ptr(__VA_ARGS__)
 #define u_strncpy(...) u_strncpy_ptr(__VA_ARGS__)

--- a/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
+++ b/src/libraries/System.Private.CoreLib/src/System.Private.CoreLib.Shared.projitems
@@ -1434,6 +1434,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathHelper.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\DisableMediaInsertionPrompt.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Marvin.OrdinalIgnoreCase.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PasteArguments.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Loader\LibraryNameVariation.Windows.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\MemoryFailPoint.Windows.cs" />
@@ -1682,6 +1683,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PathInternal.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PersistedFiles.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\IO\PersistedFiles.Names.Unix.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)System\Marvin.OrdinalIgnoreCase.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\PasteArguments.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\Loader\LibraryNameVariation.Unix.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)System\Runtime\MemoryFailPoint.Unix.cs" />

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Unix.cs
@@ -11,6 +11,8 @@ namespace System.Globalization
 {
     public partial class TextInfo
     {
+        internal const bool CaseFoldToUpper = false; // ICU folds ASCII characters to lowercase
+
         private Tristate _needsTurkishCasing = Tristate.NotInitialized;
 
         private void FinishInitialization() { }
@@ -46,6 +48,13 @@ namespace System.Globalization
                 _needsTurkishCasing = NeedsTurkishCasing(_textInfoName) ? Tristate.True : Tristate.False;
                 goto TryAgain;
             }
+        }
+
+        private unsafe void CaseFold(char* pSource, int pSourceLen, char* pResult, int pResultLen)
+        {
+            Debug.Assert(!GlobalizationMode.Invariant);
+
+            Interop.Globalization.SimpleCaseFold(pSource, pSourceLen, pResult, pResultLen);
         }
 
     }

--- a/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Globalization/TextInfo.Windows.cs
@@ -8,6 +8,8 @@ namespace System.Globalization
 {
     public partial class TextInfo
     {
+        internal const bool CaseFoldToUpper = true; // NLS doesn't perform case folding; it normalizes to uppercase
+
         private unsafe void FinishInitialization()
         {
             _sortHandle = CompareInfo.GetSortHandle(_textInfoName);
@@ -40,6 +42,11 @@ namespace System.Globalization
             }
 
             Debug.Assert(ret == pSourceLen, "Expected getting the same length of the original string");
+        }
+
+        private unsafe void CaseFold(char* pSource, int pSourceLen, char* pResult, int pResultLen)
+        {
+            throw new PlatformNotSupportedException(); // this code path shouldn't get hit on Windows
         }
 
         // PAL Ends here

--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.Unix.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.Unix.cs
@@ -1,0 +1,33 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Text.Unicode;
+
+namespace System
+{
+    internal static partial class Marvin
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint CaseFoldTwoAsciiChars(uint value)
+        {
+            Debug.Assert(Utf16Utility.AllCharsInUInt32AreAscii(value));
+
+            // ICU's case folding is a lowercase conversion in the ASCII range.
+
+            return Utf16Utility.ConvertAllAsciiCharsInUInt32ToLowercase(value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int CaseFoldBuffer(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            Debug.Assert(destination.Length >= source.Length);
+
+            TextInfo.Invariant.ToCaseFold(source, destination);
+            return source.Length; // case folding doesn't change the UTF-16 code unit count
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.Windows.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.Windows.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Text.Unicode;
+
+namespace System
+{
+    internal static partial class Marvin
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static uint CaseFoldTwoAsciiChars(uint value)
+        {
+            Debug.Assert(Utf16Utility.AllCharsInUInt32AreAscii(value));
+
+            // NLS doesn't have a concept of case folding. Instead, "removing case information"
+            // means that data is normalized to uppercase.
+
+            return Utf16Utility.ConvertAllAsciiCharsInUInt32ToUppercase(value);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static int CaseFoldBuffer(ReadOnlySpan<char> source, Span<char> destination)
+        {
+            Debug.Assert(destination.Length >= source.Length);
+
+            // NLS doesn't have a concept of case folding. Instead, "removing case information"
+            // means that data is normalized to uppercase.
+
+            return source.ToUpperInvariant(destination);
+        }
+    }
+}

--- a/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
+++ b/src/libraries/System.Private.CoreLib/src/System/Marvin.OrdinalIgnoreCase.cs
@@ -38,7 +38,7 @@ namespace System
                 {
                     goto NotAscii;
                 }
-                p0 += Utf16Utility.ConvertAllAsciiCharsInUInt32ToUppercase(tempValue);
+                p0 += CaseFoldTwoAsciiChars(tempValue);
                 Block(ref p0, ref p1);
 
                 byteOffset += 4;
@@ -57,7 +57,7 @@ namespace System
                 }
 
                 // addition is written with -0x80u to allow fall-through to next statement rather than jmp past it
-                p0 += Utf16Utility.ConvertAllAsciiCharsInUInt32ToUppercase(tempValue) + (0x800000u - 0x80u);
+                p0 += CaseFoldTwoAsciiChars(tempValue) + (0x800000u - 0x80u);
             }
             p0 += 0x80u;
 
@@ -78,10 +78,10 @@ namespace System
             char[]? borrowedArr = null;
             Span<char> scratch = (uint)count <= 64 ? stackalloc char[64] : (borrowedArr = ArrayPool<char>.Shared.Rent(count));
 
-            int charsWritten = new ReadOnlySpan<char>(ref data, count).ToUpperInvariant(scratch);
-            Debug.Assert(charsWritten == count); // invariant case conversion should involve simple folding; preserve code unit count
+            int charsWritten = CaseFoldBuffer(new ReadOnlySpan<char>(ref data, count), scratch);
+            Debug.Assert(charsWritten == count); // simple case folding should preserve code unit count
 
-            // Slice the array to the size returned by ToUpperInvariant.
+            // Slice the array to the size returned by the case folding operation.
             // Multiplication below will not overflow since going from positive Int32 to UInt32.
             int hash = ComputeHash32(ref Unsafe.As<char, byte>(ref MemoryMarshal.GetReference(scratch)), (uint)charsWritten * 2, p0, p1);
 


### PR DESCRIPTION
Clone of https://github.com/dotnet/runtime/pull/27540 so that I don't lose track of it.

-----

Fixes https://github.com/dotnet/runtime/issues/26961.

Adjusts `OrdinalIgnoreCase` string comparison routines (on ICU only) to use case folding instead of case mapping.

__Open question:__ What should we do about the special-casing logic for `U+0131` and `U+0049`? This PR aside, there are tons of differences in the case mapping tables between ICU and NLS, and the pair that is checked for here is only one such difference. I don't believe it's feasible for us to carry the delta between ICU and NLS within our runtime, which means we should probably scrap the below check and say "we're following the same behavior ICU has."

https://github.com/dotnet/runtime/blob/7aff91cded9d5c342302a9bfe12f79a740ca2370/src/libraries/Native/Unix/System.Globalization.Native/pal_collation.c#L537-L543