### PR TITLE
Randomize CoseHeaderLabel hash codes

### DIFF
--- a/src/libraries/Common/src/System/HashCodeRandomization.cs
+++ b/src/libraries/Common/src/System/HashCodeRandomization.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace System
+{
+    // Contains helpers for calculating randomized hash codes of common types.
+    // These hash codes must not be persisted between AppDomain restarts.
+    // There's still the potential for two distinct types with the same bit
+    // pattern (for example, string.Empty and int.Zero) to produce the same
+    // hash code, since the HashCode seed is global per AppDomain and not per type.
+    // This shouldn't be a problem for most callers since the number of
+    // possible types is expected to be small anyway for realistic scenarios.
+    internal static class HashCodeRandomization
+    {
+        public static int GetRandomizedOrdinalHashCode(this string value)
+        {
+#if NETCOREAPP
+            // In .NET Core, string hash codes are already randomized.
+
+            return value.GetHashCode();
+#else
+            // Downlevel, we need to perform randomization ourselves.
+            // This allows "Hello!" and "Hello!\0" to have the same hash
+            // code, which is acceptable for the scenarios we care about.
+            // We'll pull out pairs of chars and write 32-bit ints at a time.
+
+            HashCode hashCode = default;
+            int pair = 0;
+            for (int i = 0; i < value.Length; i++)
+            {
+                int ch = value[i];
+                if ((i & 1) == 0)
+                {
+                    pair = ch << 16; // first member of pair
+                }
+                else
+                {
+                    pair |= ch; // second member of pair
+                    hashCode.Add(pair); // write pair as single unit
+                    pair = 0;
+                }
+            }
+            hashCode.Add(pair); // flush any leftover data (could be 0)
+            return hashCode.ToHashCode();
+#endif
+        }
+
+        public static int GetRandomizedHashCode(this int value)
+        {
+            return HashCode.Combine(value);
+        }
+    }
+}

--- a/src/libraries/System.Security.Cryptography.Cose/src/System.Security.Cryptography.Cose.csproj
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System.Security.Cryptography.Cose.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="$(CommonPath)System\HashCodeRandomization.cs" Link="Common\System\HashCodeRandomization.cs" />
     <Compile Include="$(CommonPath)System\Memory\PointerMemoryManager.cs" Link="Common\System\Memory\PointerMemoryManager.cs" />
     <Compile Include="$(LibrariesProjectRoot)System.Formats.Cbor\src\System\Formats\Cbor\CborInitialByte.cs" Link="System\Formats\Cbor\CborInitialByte.cs" />
     <Compile Include="System\Security\Cryptography\Cose\CoseHeaderLabel.cs" />
@@ -30,6 +31,11 @@
 
   <ItemGroup>
     <ProjectReference Include="$(LibrariesProjectRoot)System.Formats.Cbor\src\System.Formats.Cbor.csproj" />
+  </ItemGroup>
+
+  <!-- For System.HashCode -->
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETCoreApp'">
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="$(MicrosoftBclHashCodeVersion)" />
   </ItemGroup>
 
   <!-- For IncrementalHash -->

--- a/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseHeaderLabel.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/src/System/Security/Cryptography/Cose/CoseHeaderLabel.cs
@@ -54,12 +54,16 @@ namespace System.Security.Cryptography.Cose
 
         public override int GetHashCode()
         {
+            // Since this type is used as a key in a dictionary (see CoseHeaderMap)
+            // and since the label is potentially adversary-provided, we'll need
+            // to randomize the hash code.
+
             if (LabelAsString != null)
             {
-                return LabelAsString.GetHashCode();
+                return LabelAsString.GetRandomizedOrdinalHashCode();
             }
 
-            return LabelAsInt32.GetHashCode();
+            return LabelAsInt32.GetRandomizedHashCode();
         }
 
         public static bool operator ==(CoseHeaderLabel left, CoseHeaderLabel right) => left.Equals(right);

--- a/src/libraries/System.Security.Cryptography.Cose/tests/CoseHeaderLabelTests.cs
+++ b/src/libraries/System.Security.Cryptography.Cose/tests/CoseHeaderLabelTests.cs
@@ -10,23 +10,35 @@ namespace System.Security.Cryptography.Cose.Tests
         [Fact]
         public void CoseHeaderLabel_GetHashCode()
         {
-            CoseHeaderLabel label = default;
-            Assert.Equal(0, label.GetHashCode()); // There's no need to call GetHashCode on integers as they are their own hashcode.
+            // First, construct a COSE header of (0) using several different methods.
+            // They should all have the same hash code, though we don't know what
+            // the hash code is.
 
-            label = new CoseHeaderLabel();
-            Assert.Equal(0, label.GetHashCode());
+            CoseHeaderLabel label1 = default;
+            CoseHeaderLabel label2 = new CoseHeaderLabel();
+            CoseHeaderLabel label3 = new CoseHeaderLabel(0);
 
-            label = new CoseHeaderLabel(0);
-            Assert.Equal(0, label.GetHashCode());
+            int label1HashCode = label1.GetHashCode();
+            Assert.Equal(label1HashCode, label2.GetHashCode());
+            Assert.Equal(label1HashCode, label3.GetHashCode());
 
-            label = new CoseHeaderLabel("");
-            Assert.Equal("".GetHashCode(), label.GetHashCode());
+            // Make sure the integer hash code calculation really is randomized.
+            // Checking 1 & 2 together rather than independently cuts the false
+            // positive rate down to nearly 1 in 2^64.
 
-            label = new CoseHeaderLabel(1);
-            Assert.Equal(1, label.GetHashCode());
+            bool isReturningNormalInt32HashCode =
+                (new CoseHeaderLabel(1).GetHashCode() == 1)
+                && (new CoseHeaderLabel(2).GetHashCode() == 2);
+            Assert.False(isReturningNormalInt32HashCode);
 
-            label = new CoseHeaderLabel("content-type");
-            Assert.Equal("content-type".GetHashCode(), label.GetHashCode());
+            // Make sure the string hash code calculation really is randomized.
+            // Checking 1 & 2 together rather than independently cuts the false
+            // positive rate down to nearly 1 in 2^64.
+
+            bool isReturningNormalStringHashCode =
+                (new CoseHeaderLabel("Hello").GetHashCode() == "Hello".GetHashCode())
+                && (new CoseHeaderLabel("World").GetHashCode() == "World".GetHashCode());
+            Assert.Equal(PlatformDetection.IsNetCore, isReturningNormalStringHashCode);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

`Dictionary<TKey, TValue>` instances are not secure against untrusted inputs except for when `TKey = string`. In our scenario, since COSE header values are adversary-provided and the COSE message is backed by an `Dictionary<CoseHeaderLabel, ...>` populated by attacker-provided keys, this represents an algorithmic complexity (hash code collision) DoS attack vector.

Note the demonstration below, which shows a clear _O(n^2)_ algorithmic complexity as _n_ entries are added to the map.

```cs
static void RunTest(int collidingKeyCount)
{
    var map = new CoseHeaderMap();
    var collidingKeys = GenerateCollidingKeys(collidingKeyCount);

    Stopwatch sw = Stopwatch.StartNew();
    foreach (var key in collidingKeys)
    {
        map.SetValue(key, 42);
    }
    sw.Stop();

    Console.WriteLine($"Took {sw.Elapsed} time to add {collidingKeyCount} entries.");
}
```
```txt
Took 00:00:00.0009202 time to add 1000 entries.
Took 00:00:00.0035026 time to add 2000 entries.
Took 00:00:00.0274130 time to add 4000 entries.
Took 00:00:00.0801631 time to add 8000 entries.
Took 00:00:00.2482827 time to add 16000 entries.
Took 00:00:00.9334852 time to add 32000 entries.
```

## Discussion

The downlevel "generate a randomized string hash code value" logic could be a little faster, but at that point it would require dropping down to unsafe-equivalent code. I didn't want to do that here until we have real evidence that we need such an optimization.

I also didn't add a "validate that there aren't a significant number of collisions in the dictionary" unit test because they're very complicated and take a while to run. [See here](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Collections/tests/Generic/Dictionary/HashCollisionScenarios/OutOfBoundsRegression.cs) for an example of such a test elsewhere in our repo. I updated the existing `CoseHeaderLabel.GetHashCode` unit test so that it will catch the case where somebody inadvertently reverts the method logic. That should be sufficient here, but I'm open to suggestions if you feel this needs more coverage.